### PR TITLE
Fix mobile footer layout and horizontal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
             position: fixed;
             top: 0;
             left: 0;
-            width: 100vw;
+            width: 100%;
             height: 100vh;
             pointer-events: none;
             animation: noise 2s steps(1) infinite;
@@ -345,7 +345,7 @@
     <!-- Footer -->
     <footer class="bg-black/50 border-t border-purple-800/50">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
-            <div class="flex flex-col md:flex-row justify-between items-center text-center md:text-left space-y-8 md:space-y-0">
+            <div class="flex flex-col md:flex-row items-center text-center md:text-left space-y-8 md:space-y-0 md:justify-between">
                 <div class="flex items-center space-x-3">
                      <span class="text-xl font-semibold font-['Orbitron',_sans-serif]">LEX VERSE</span>
                 </div>


### PR DESCRIPTION
This commit addresses two issues on mobile devices:
1.  Horizontal scrolling caused by `width: 100vw` on a pseudo-element. This has been changed to `width: 100%` to prevent overflow.
2.  Incorrect alignment of footer elements. The Tailwind CSS classes have been adjusted to ensure the footer content is properly centered on mobile screens while maintaining the original layout on larger screens.